### PR TITLE
Cart item count

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11976,6 +11976,11 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-multiline-clamp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/react-multiline-clamp/-/react-multiline-clamp-1.0.6.tgz",
+      "integrity": "sha512-rMc0gNB/K5OUF9O+b8Yb0eSm9M2aU+3puq9T67bjvlXPxPfdUT9dQKo+LPrrGWsKx8QKC33o7O0wc3Fpw7prUw=="
+    },
     "react-overlays": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-bootstrap": "^1.6.0",
     "react-dom": "^17.0.2",
     "react-icons": "^4.2.0",
+    "react-multiline-clamp": "^1.0.6",
     "react-router-bootstrap": "^0.25.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",

--- a/src/components/Cart.jsx
+++ b/src/components/Cart.jsx
@@ -3,20 +3,20 @@ import { faShoppingCart } from '@fortawesome/free-solid-svg-icons';
 import { Wrapper, Icon, CartCount, CartSideBar, EmptyCart } from './CartStyles.jsx';
 import useOnClickOutside from './useOnClickOutside';
 
-export default function Cart({ isToggle, setToggle }) {
+export default function Cart(props) {
     const [itemCount, setItemCount] = useState(0)
 
     const $sideBarRef = useRef();
     //handle the onclick outside 
-    useOnClickOutside($sideBarRef, () => setToggle(false));
+    useOnClickOutside($sideBarRef, () => props.setToggle(false));
 
     return <>
-        <Wrapper onClick={() => setToggle(true)}>
+        <Wrapper onClick={() => props.setToggle(true)}>
             <Icon icon={faShoppingCart} />
-            <CartCount>{ itemCount }</CartCount>
+            <CartCount>{ props.count }</CartCount>
         </Wrapper>
         
-        <CartSideBar ref={$sideBarRef} className={isToggle ? "expand" : "shrink"}>
+        <CartSideBar ref={$sideBarRef} className={props.isToggle ? "expand" : "shrink"}>
             <sideBarHeader>Shppoing Cart</sideBarHeader>
             <EmptyCart>Empty Cart</EmptyCart>
         </CartSideBar>

--- a/src/components/Cart.jsx
+++ b/src/components/Cart.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { faShoppingCart } from '@fortawesome/free-solid-svg-icons';
 import { Wrapper, Icon, CartCount, CartSideBar, EmptyCart } from './CartStyles.jsx';
 import useOnClickOutside from './useOnClickOutside';
@@ -8,10 +8,16 @@ export default function Cart(props) {
     //handle the onclick outside 
     useOnClickOutside($sideBarRef, () => props.setToggle(false))
 
+    const [itemCount, setItemCount] = useState(props.count)
+    
+    useEffect(() => {
+        setItemCount(props.count)
+    })
+
     return <>
         <Wrapper onClick={() => props.setToggle(true)}>
             <Icon icon={faShoppingCart} />
-            <CartCount>{ props.count }</CartCount>
+            <CartCount>{ itemCount }</CartCount>
         </Wrapper>
         
         <CartSideBar ref={$sideBarRef} className={props.isToggle ? "expand" : "shrink"}>

--- a/src/components/Cart.jsx
+++ b/src/components/Cart.jsx
@@ -4,11 +4,9 @@ import { Wrapper, Icon, CartCount, CartSideBar, EmptyCart } from './CartStyles.j
 import useOnClickOutside from './useOnClickOutside';
 
 export default function Cart(props) {
-    const [itemCount, setItemCount] = useState(0)
-
     const $sideBarRef = useRef();
     //handle the onclick outside 
-    useOnClickOutside($sideBarRef, () => props.setToggle(false));
+    useOnClickOutside($sideBarRef, () => props.setToggle(false))
 
     return <>
         <Wrapper onClick={() => props.setToggle(true)}>

--- a/src/components/CategorySection.jsx
+++ b/src/components/CategorySection.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React,{useState} from 'react';
 import ItemCard from './ItemCard';
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
@@ -7,6 +7,17 @@ import { Link } from 'react-router-dom';
 import { LinkContainer } from 'react-router-bootstrap';
 
 export default function CategorySection(props) {
+	const [itemCount, setItemCount] = useState(localStorage.getItem('totalCount'))
+
+	const handleAddToCart = (event) => {
+		const total = parseInt(localStorage.getItem('totalCount'))
+		const preCount = parseInt(localStorage.getItem(event.target.offsetParent.id))
+		localStorage.setItem(event.target.offsetParent.id, (1 + preCount))
+        localStorage.setItem('totalCount', (total + 1))
+        setItemCount(total + 1)
+        // console.log(event.target.offsetParent.id)
+	};
+
 	// pick unique three number, and return them as an array
 	function randThreeNums(items) {
 		if (items.length !== 0) {
@@ -44,6 +55,7 @@ export default function CategorySection(props) {
 										}}
 										price={props.items[num].price}
 										onClick={props.onClick}
+										addToCart={handleAddToCart}
 									/>
 								</Col>
 							);

--- a/src/components/CategorySection.jsx
+++ b/src/components/CategorySection.jsx
@@ -7,17 +7,6 @@ import { Link } from 'react-router-dom';
 import { LinkContainer } from 'react-router-bootstrap';
 
 export default function CategorySection(props) {
-	const [itemCount, setItemCount] = useState(localStorage.getItem('totalCount'))
-
-	const handleAddToCart = (event) => {
-		const total = parseInt(localStorage.getItem('totalCount'))
-		const preCount = parseInt(localStorage.getItem(event.target.offsetParent.id))
-		localStorage.setItem(event.target.offsetParent.id, (1 + preCount))
-        localStorage.setItem('totalCount', (total + 1))
-        setItemCount(total + 1)
-        // console.log(event.target.offsetParent.id)
-	};
-
 	// pick unique three number, and return them as an array
 	function randThreeNums(items) {
 		if (items.length !== 0) {
@@ -55,7 +44,7 @@ export default function CategorySection(props) {
 										}}
 										price={props.items[num].price}
 										onClick={props.onClick}
-										addToCart={handleAddToCart}
+										addToCart={props.addToCart}
 									/>
 								</Col>
 							);

--- a/src/components/Electronics.jsx
+++ b/src/components/Electronics.jsx
@@ -7,7 +7,17 @@ import { Container } from 'react-bootstrap';
 export default function Electronics(props) {
 	const [electronics, setElectronics] = useState([]);
 	const [showDetail, setShowDetail] = useState(false); // Switch with detail page.
-	const [index, setIndex] = useState('');
+    const [index, setIndex] = useState('');
+    const [itemCount, setItemCount] = useState(localStorage.getItem('totalCount'))
+
+	const handleAddToCart = (event) => {
+		const total = parseInt(localStorage.getItem('totalCount'))
+		const preCount = parseInt(localStorage.getItem(event.target.offsetParent.id))
+		localStorage.setItem(event.target.offsetParent.id, (1 + preCount))
+        localStorage.setItem('totalCount', (total + 1))
+        setItemCount(total + 1)
+        // console.log(event.target.offsetParent.id)
+	};
 
 	function filterCategory(arr, categoryName) {
         return arr.filter((obj) => obj.category === categoryName);
@@ -35,14 +45,14 @@ export default function Electronics(props) {
         electronics.length === 0 ? (
                 <>
                     <header>
-                        <Navigation count={localStorage.getItem('totalCount')} />
+                        <Navigation count={itemCount} />
                     </header>
                     <section>Loading...</section>
                 </>
             ) : (
                 <>
                     <header>
-                        <Navigation count={localStorage.getItem('totalCount')} />
+                        <Navigation count={itemCount} />
                     </header>
                     <Container
                         style={{
@@ -65,6 +75,7 @@ export default function Electronics(props) {
                                 }}
                                 price={data.price}
                                 onClick={handleShowDetail}
+                                addToCart={handleAddToCart}
                             />
                         })}
 

--- a/src/components/Electronics.jsx
+++ b/src/components/Electronics.jsx
@@ -17,7 +17,9 @@ export default function Electronics(props) {
 	// Handle 'showDetail' status.
 	function handleShowDetail(event) {
 		setIndex(event.currentTarget.id);
-        setShowDetail(!showDetail);
+		if (event.target.localName !== 'button') {
+			setShowDetail(!showDetail)
+		}
 	}
 
 	useEffect(() => {
@@ -33,14 +35,14 @@ export default function Electronics(props) {
         electronics.length === 0 ? (
                 <>
                     <header>
-                        <Navigation />
+                        <Navigation count={localStorage.getItem('totalCount')} />
                     </header>
                     <section>Loading...</section>
                 </>
             ) : (
                 <>
                     <header>
-                        <Navigation />
+                        <Navigation count={localStorage.getItem('totalCount')} />
                     </header>
                     <Container
                         style={{

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -11,6 +11,16 @@ export default function Home() {
 	const [womenClothing, setWomenClothing] = useState([]);
 	const [showDetail, setShowDetail] = useState(false); // Switch with detail page.
 	const [index, setIndex] = useState('');
+	const [itemCount, setItemCount] = useState(localStorage.getItem('totalCount'))
+
+	const handleAddToCart = (event) => {
+		const total = parseInt(localStorage.getItem('totalCount'))
+		const preCount = parseInt(localStorage.getItem(event.target.offsetParent.id))
+		localStorage.setItem(event.target.offsetParent.id, (1 + preCount))
+        localStorage.setItem('totalCount', (total + 1))
+        setItemCount(total + 1)
+        // console.log(event.target.offsetParent.id)
+	};
 
 	function filterCategory(arr, categoryName) {
 		return arr.filter((obj) => obj.category === categoryName);
@@ -50,14 +60,14 @@ export default function Home() {
 		allData.length === 0 ? (
 			<>
 				<header>
-					<Navigation count={localStorage.getItem('totalCount')} />
+					<Navigation count={itemCount} />
 				</header>
 				<section>Loading...</section>
 			</>
 		) : (
 			<>
 				<header>
-					<Navigation count={localStorage.getItem('totalCount')} />
+					<Navigation count={itemCount} />
 				</header>
 				<section
 					data-bs-spy="scroll"
@@ -70,24 +80,28 @@ export default function Home() {
 						items={electronics}
 						onClick={(event) => handleShowDetail(event)}
 						link="/electronics"
+						addToCart={handleAddToCart}
 					/>
 					<CategorySection
 						category="Jewelery"
 						items={jewelery}
 						onClick={(event) => handleShowDetail(event)}
 						link="/jewelery"
+						addToCart={handleAddToCart}
 					/>
 					<CategorySection
 						category="Men's Clothing"
 						items={menClothing}
 						onClick={(event) => handleShowDetail(event)}
 						link="/men"
+						addToCart={handleAddToCart}
 					/>
 					<CategorySection
 						category="Women's Clothing"
 						items={womenClothing}
 						onClick={(event) => handleShowDetail(event)}
 						link="/women"
+						addToCart={handleAddToCart}
 					/>
 				</section>
 			</>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -2,12 +2,6 @@ import React, { useState, useEffect } from 'react';
 import CategorySection from './CategorySection';
 import ItemDetail from './ItemDetail';
 import Navigation from './Navigation';
-import {
-	BrowserRouter as Router,
-	Switch,
-	Rout,
-	Link
-} from 'react-router-dom'
 
 export default function Home() {
 	const [allData, setAllData] = useState([]);
@@ -25,7 +19,9 @@ export default function Home() {
 	// Handle 'showDetail' status.
 	function handleShowDetail(event) {
 		setIndex(event.currentTarget.id);
-		setShowDetail(!showDetail);
+		if (event.target.localName !== 'button') {
+			setShowDetail(!showDetail)
+		}
 	}
 
 	useEffect(() => {
@@ -39,6 +35,10 @@ export default function Home() {
 				setWomenClothing(filterCategory(json, "women's clothing"));
 			})
 			.catch((err) => console.error(`Fetch Error: ${err}`));
+		
+		for (let i = 0; i < allData.length; i++){
+			localStorage.setItem((i+1), 0)
+		}
 	}, []);
 
 	return !showDetail ? (
@@ -69,19 +69,19 @@ export default function Home() {
 					<CategorySection
 						category="Jewelery"
 						items={jewelery}
-						onClick={handleShowDetail}
+						onClick={(event) => handleShowDetail(event)}
 						link="/jewelery"
 					/>
 					<CategorySection
 						category="Men's Clothing"
 						items={menClothing}
-						onClick={handleShowDetail}
+						onClick={(event) => handleShowDetail(event)}
 						link="/men"
 					/>
 					<CategorySection
 						category="Women's Clothing"
 						items={womenClothing}
-						onClick={handleShowDetail}
+						onClick={(event) => handleShowDetail(event)}
 						link="/women"
 					/>
 				</section>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -39,9 +39,11 @@ export default function Home() {
 		for (let i = 0; i < allData.length; i++){
 			localStorage.setItem((i+1), 0)
 		}
+		if (!localStorage.getItem('totalCount')) {
+			
+			localStorage.setItem('totalCount', 0)
+		}
 
-		localStorage.setItem('totalCount', 0)
-		
 	}, []);
 
 	return !showDetail ? (

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -39,20 +39,23 @@ export default function Home() {
 		for (let i = 0; i < allData.length; i++){
 			localStorage.setItem((i+1), 0)
 		}
+
+		localStorage.setItem('totalCount', 0)
+		
 	}, []);
 
 	return !showDetail ? (
 		allData.length === 0 ? (
 			<>
 				<header>
-					<Navigation />
+					<Navigation count={localStorage.getItem('totalCount')} />
 				</header>
 				<section>Loading...</section>
 			</>
 		) : (
 			<>
 				<header>
-					<Navigation />
+					<Navigation count={localStorage.getItem('totalCount')} />
 				</header>
 				<section
 					data-bs-spy="scroll"
@@ -89,9 +92,6 @@ export default function Home() {
 		)
 	) : (
 		<>
-			<header>
-				<Navigation />
-			</header>
 			<ItemDetail item={allData.filter((item) => item.id === index)[0]} />
 		</>
 	);

--- a/src/components/ItemCard.jsx
+++ b/src/components/ItemCard.jsx
@@ -1,14 +1,10 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import Button from 'react-bootstrap/Button';
 import Card from 'react-bootstrap/Card';
+import Clamp from 'react-multiline-clamp';
 
 export default function ItemCard(props) {
-	const handleAddToCart = () => {
-		const total = parseInt(localStorage.getItem('totalCount'))
-		const preCount = parseInt(localStorage.getItem(props.id))
-		localStorage.setItem(props.id, (1 + preCount))
-		localStorage.setItem('totalCount', (total + 1))
-	};
+	
 
 	return (
 		<Card
@@ -29,20 +25,19 @@ export default function ItemCard(props) {
 				<Card.Title
 					style={{
 						'font-size': '100%',
-						'text-overflow': 'ellipsis',
-						'white-space': 'nowrap',
-						overflow: 'hidden',
 						margin: 0,
 					}}
 				>
-					{props.title}
+					<Clamp lines={2} withTooltip>
+						{props.title}
+					</Clamp>
 				</Card.Title>
 				<Card.Subtitle className="m-0 text-muted">${props.price}</Card.Subtitle>
 				<Button
 					onclick="addToCart()"
 					variant="primary"
 					className="d-block mx-auto rounded-pill"
-					onClick={() => handleAddToCart()}
+					onClick={(event)=>props.addToCart(event)}
 				>
 					Add to Cart
 				</Button>

--- a/src/components/ItemCard.jsx
+++ b/src/components/ItemCard.jsx
@@ -3,6 +3,13 @@ import Button from 'react-bootstrap/Button';
 import Card from 'react-bootstrap/Card';
 
 export default function ItemCard(props) {
+	const handleAddToCart = () => {
+		const total = parseInt(localStorage.getItem('totalCount'))
+		const preCount = parseInt(localStorage.getItem(props.id))
+		localStorage.setItem(props.id, (1 + preCount))
+		localStorage.setItem('totalCount', (total + 1))
+	};
+
 	return (
 		<Card
 			key={props.key}
@@ -35,6 +42,7 @@ export default function ItemCard(props) {
 					onclick="addToCart()"
 					variant="primary"
 					className="d-block mx-auto rounded-pill"
+					onClick={() => handleAddToCart()}
 				>
 					Add to Cart
 				</Button>

--- a/src/components/ItemDetail.jsx
+++ b/src/components/ItemDetail.jsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React, { useState } from 'react';
 import {
 	Button,
 	Image,
@@ -10,9 +10,10 @@ import {
 } from 'react-bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import Navigation from './Navigation';
+import Clamp from 'react-multiline-clamp';
 
 function ItemDetail(props) {
-	const [itemCount, setItemCount] = useState(0)
+	const [itemCount, setItemCount] = useState(localStorage.getItem('totalCount'))
 	const [qty, setQty] = useState(1);
 
 	const handleAddToCart = () => {
@@ -20,137 +21,151 @@ function ItemDetail(props) {
 		const preCount = parseInt(localStorage.getItem(props.item.id))
 		localStorage.setItem(props.item.id, (qty + preCount))
 		localStorage.setItem('totalCount', (total + qty))
+		setItemCount((total + qty))
 	};
 
 	const handleCountOnChange = (event) => {
-		console.log(typeof event.target.value)
 		setQty(parseInt(event.target.value))
 	}
 
 	return (
 		<>
-			<Navigation
-				count={localStorage.getItem('totalCount')}
-			/>
-		<Container fluid >
-			<Row
-				className='mx-auto justify-content-between'
-				style={{
-					width: '80%',
-					height: '80vh',
-					marginTop: '120px'
-				}}
-			>
-				<Col
-					md={5}
+			<Navigation count={itemCount} />
+			<Container fluid >
+				<Row
+					className='mx-auto justify-content-between'
+					style={{
+						width: '80%',
+						height: '80vh',
+						marginTop: '120px'
+					}}
 				>
-					<Row className='justify-content-center mb-4'>
-						<Image
+					<Col md={5} >
+						<Row className='justify-content-center mb-4'>
+							<Image
+								style={{
+									maxWidth: '100%',
+									maxHeight: '500px'
+								}}
+								src={props.item.image} rounded
+							/>
+						</Row>
+						<Row className='d-flex justify-content-between'  >
+								<Image
+									style={{
+										maxHeight: '200px',
+										maxWidth: '150px'
+									}}
+									src={props.item.image}
+									rounded
+								/>
+								<Image
+									style={{
+										maxHeight: '200px',
+										maxWidth: '150px'
+									}}
+									src={props.item.image}
+									rounded
+								/>
+								<Image
+									style={{
+										maxHeight: '200px',
+										maxWidth: '150px'
+									}}
+									src={props.item.image} rounded />
+						</Row>
+					</Col>
+					<Col md={6}>
+						<Card
+							className="d-flex flex-column p-3"
 							style={{
-								maxWidth: '100%',
-								maxHeight: '500px'
-							}}
-							src={props.item.image} rounded
-						/>
-					</Row>
-					<Row className='d-flex justify-content-between'  >
-							<Image
-								style={{
-									maxHeight: '200px',
-									maxWidth: '150px'
-								}}
-								src={props.item.image} rounded />
-							<Image
-								style={{
-									maxHeight: '200px',
-									maxWidth: '150px'
-								}}
-								src={props.item.image} rounded />
-							<Image
-								style={{
-									maxHeight: '200px',
-									maxWidth: '150px'
-								}}
-								src={props.item.image} rounded />
-					</Row>
-				</Col>
-				<Col md={6}>
-					<Card
-						className='d-flex flex-column p-3'
-						style={{
-							maxHeight: '750px'
-						}}
-					>
-						<Card.Body>
-							<Card.Title
-								style={{
-									marginBottom: '30px',
-									fontSize: '30px'
-									
-								}}
-							>{props.item.title}</Card.Title>
-							<Card.Subtitle
-								style={{
-									marginBottom: '10px',
-									fontSize: '15px'
-								}}
-							>{props.item.category}</Card.Subtitle>
-							<Card.Text
-								style={{
-									fontSize: '30px'
-								}}
-							>${props.item.price}</Card.Text>
-							<Card.Text
-								style={{
-									overflow: 'hidden',
-									maxHeight: '250px',
-									fontSize: '13px'
-								}}
-							>{props.item.description}</Card.Text>
-						</Card.Body>
-						<Form
-							style={{
-								width: '180px',
-								margin: '20px'
+								minHeight: '750px',
 							}}
 						>
-							<Form.Group controlId='qty' className='w-50'>
-								<Form.Label>Qty: </Form.Label>
-								<Form.Control
-									size='sm'
-									type='number'
-									defaultValue={1}
-									onChange={(event) => handleCountOnChange(event)}
-								/>
-							</Form.Group>
-							{(props.item.category === "men's clothing" || props.item.category === "women's clothing") &&
-								<Form.Group controlId="size">
-									<Form.Label>Size: </Form.Label>
-									<Form.Control as="select" size='sm' defaultValue='m'>
-										<option value="xs">XS</option>
-										<option value="s">S</option>
-										<option value="m">M</option>
-										<option value="l">L</option>
-										<option value="xl">XL</option>
-									</Form.Control>
-									
+							<Card.Body>
+								<Card.Title
+									style={{
+										'margin-bottom': '30px',
+										'font-size': '30px',
+									}}
+								>
+									{props.item.title}
+								</Card.Title>
+								<Card.Subtitle
+									style={{
+										'margin-bottom': '10px',
+										'font-size': '15px',
+									}}
+								>
+									{props.item.category}
+								</Card.Subtitle>
+								<Card.Text
+									style={{
+										'font-size': '30px',
+									}}
+								>
+									${props.item.price}
+								</Card.Text>
+								<Card.Text
+									style={{
+										'max-height': '250px',
+										'font-size': '13px',
+									}}
+								>
+									<Clamp
+										lines={5}
+										withToggle
+										texts={{ showMore: 'show more', showLess: 'show less' }}
+									>
+										{props.item.description}
+									</Clamp>
+								</Card.Text>
+							</Card.Body>
+							<Form
+								style={{
+									width: '180px',
+									margin: '20px',
+								}}
+							>
+								<Form.Group controlId="qty" className="w-50">
+									<Form.Label>Qty: </Form.Label>
+									<Form.Control
+										size="sm"
+										type="number"
+										defaultValue={1}
+										onChange={(event) => handleCountOnChange(event)}
+									/>
 								</Form.Group>
-							}
-						</Form>
-						<Button
-							style={{
-								width: '180px',
-								alignSelf: 'flex-end',
-								margin: '20px'
-							}}
-							onClick={() => handleAddToCart()}
-						>Add to cart</Button>
-					</Card>
-				</Col>
-			</Row>
+								{(props.item.category === "men's clothing" ||
+									props.item.category === "women's clothing") && (
+									<Form.Group controlId="size">
+										<Form.Label>Size: </Form.Label>
+										<Form.Control as="select" size="sm" defaultValue="m">
+											<option value="xs">XS</option>
+											<option value="s">S</option>
+											<option value="m">M</option>
+											<option value="l">L</option>
+											<option value="xl">XL</option>
+										</Form.Control>
+									</Form.Group>
+								)}
+							</Form>
+							<Button
+								style={{
+									width: '180px',
+									alignSelf: 'flex-end',
+									margin: '20px',
+								}}
+								onClick={() => handleAddToCart()}
+							>
+								Add to cart
+							</Button>
+						</Card>
+					</Col>
+				</Row>
 			</Container>
-			</>
-	);
-}
+		</>
+	)
+};
 
 export default ItemDetail;

--- a/src/components/ItemDetail.jsx
+++ b/src/components/ItemDetail.jsx
@@ -10,27 +10,38 @@ import {
 } from 'react-bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import Navigation from './Navigation';
+import { getSuggestedQuery } from '@testing-library/dom';
 
 function ItemDetail(props) {
-	const [itemCount, setItemCount] = useState(null)
+	const [itemCount, setItemCount] = useState(0)
 	const [qty, setQty] = useState(1);
 
 	const handleAddToCart = () => {
-		setItemCount(qty)
+		const preCount = parseInt(localStorage.getItem(props.item.id))
+		localStorage.setItem(props.item.id, (qty + preCount))
+		console.log(typeof preCount, typeof qty)
+		console.log(localStorage.getItem(props.item.id))
+		setItemCount(localStorage.getItem(props.item.id))
+		// localStorage.setItem(props.item.id, 0)
 	};
+
+	const handleCountOnChange = (event) => {
+		console.log(typeof event.target.value)
+		setQty(parseInt(event.target.value))
+	}
 
 	return (
 		<>
 			<Navigation
-				itemCount={itemCount}
+				addCount={itemCount}
 			/>
 		<Container fluid >
 			<Row
 				className='mx-auto justify-content-between'
 				style={{
-					'width': '80%',
-					'height': '80vh',
-					'margin-top': '120px'
+					width: '80%',
+					height: '80vh',
+					marginTop: '120px'
 				}}
 			>
 				<Col
@@ -42,8 +53,8 @@ function ItemDetail(props) {
 					<Row className='justify-content-center mb-4'>
 						<Image
 							style={{
-								'max-width': '100%',
-								'max-height': '500px'
+								maxWidth: '100%',
+								maxHeight: '500px'
 							}}
 							src={props.item.image} rounded
 						/>
@@ -51,20 +62,20 @@ function ItemDetail(props) {
 					<Row className='d-flex justify-content-between'  >
 							<Image
 								style={{
-									'max-height': '200px',
-									'max-width': '150px'
+									maxHeight: '200px',
+									maxWidth: '150px'
 								}}
 								src={props.item.image} rounded />
 							<Image
 								style={{
-									'max-height': '200px',
-									'max-width': '150px'
+									maxHeight: '200px',
+									maxWidth: '150px'
 								}}
 								src={props.item.image} rounded />
 							<Image
 								style={{
-									'max-height': '200px',
-									'max-width': '150px'
+									maxHeight: '200px',
+									maxWidth: '150px'
 								}}
 								src={props.item.image} rounded />
 					</Row>
@@ -73,26 +84,26 @@ function ItemDetail(props) {
 					<Card
 						className='d-flex flex-column p-3'
 						style={{
-							'max-height': '750px'
+							maxHeight: '750px'
 						}}
 					>
 						<Card.Body>
 							<Card.Title
 								style={{
-									'margin-bottom': '30px',
-									'font-size': '30px'
+									marginBottom: '30px',
+									fontSize: '30px'
 									
 								}}
 							>{props.item.title}</Card.Title>
 							<Card.Subtitle
 								style={{
-									'margin-bottom': '10px',
-									'font-size': '15px'
+									marginBottom: '10px',
+									fontSize: '15px'
 								}}
 							>{props.item.category}</Card.Subtitle>
 							<Card.Text
 								style={{
-									'font-size': '30px'
+									fontSize: '30px'
 								}}
 							>${props.item.price}</Card.Text>
 							<Card.Text
@@ -101,16 +112,16 @@ function ItemDetail(props) {
 									// 'width': '100%',
 									// 'text-overflow': 'ellipsis',
 									// 'white-space': 'nowrap',
-									'overflow': 'hidden',
-									'max-height': '250px',
-									'font-size': '13px'
+									overflow: 'hidden',
+									maxHeight: '250px',
+									fontSize: '13px'
 								}}
 							>{props.item.description}</Card.Text>
 						</Card.Body>
 						<Form
 							style={{
-								'width': '180px',
-								'margin': '20px'
+								width: '180px',
+								margin: '20px'
 							}}
 						>
 							<Form.Group controlId='qty' className='w-50'>
@@ -119,7 +130,7 @@ function ItemDetail(props) {
 									size='sm'
 									type='number'
 									defaultValue={1}
-									onChange={() => setQty()}
+									onChange={(event) => handleCountOnChange(event)}
 								/>
 							</Form.Group>
 							{(props.item.category === "men's clothing" || props.item.category === "women's clothing") &&
@@ -138,9 +149,9 @@ function ItemDetail(props) {
 						</Form>
 						<Button
 							style={{
-								'width': '180px',
-								'align-self': 'flex-end',
-								'margin': '20px'
+								width: '180px',
+								alignSelf: 'flex-end',
+								margin: '20px'
 							}}
 							onClick={() => handleAddToCart()}
 						>Add to cart</Button>

--- a/src/components/ItemDetail.jsx
+++ b/src/components/ItemDetail.jsx
@@ -10,19 +10,16 @@ import {
 } from 'react-bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import Navigation from './Navigation';
-import { getSuggestedQuery } from '@testing-library/dom';
 
 function ItemDetail(props) {
 	const [itemCount, setItemCount] = useState(0)
 	const [qty, setQty] = useState(1);
 
 	const handleAddToCart = () => {
+		const total = parseInt(localStorage.getItem('totalCount'))
 		const preCount = parseInt(localStorage.getItem(props.item.id))
 		localStorage.setItem(props.item.id, (qty + preCount))
-		console.log(typeof preCount, typeof qty)
-		console.log(localStorage.getItem(props.item.id))
-		setItemCount(localStorage.getItem(props.item.id))
-		// localStorage.setItem(props.item.id, 0)
+		localStorage.setItem('totalCount', (total + qty))
 	};
 
 	const handleCountOnChange = (event) => {
@@ -33,7 +30,7 @@ function ItemDetail(props) {
 	return (
 		<>
 			<Navigation
-				addCount={itemCount}
+				count={localStorage.getItem('totalCount')}
 			/>
 		<Container fluid >
 			<Row
@@ -46,9 +43,6 @@ function ItemDetail(props) {
 			>
 				<Col
 					md={5}
-					style={{
-						// 'height': '100%'
-					}}
 				>
 					<Row className='justify-content-center mb-4'>
 						<Image
@@ -108,10 +102,6 @@ function ItemDetail(props) {
 							>${props.item.price}</Card.Text>
 							<Card.Text
 								style={{
-									// 'display': 'inline-block',
-									// 'width': '100%',
-									// 'text-overflow': 'ellipsis',
-									// 'white-space': 'nowrap',
 									overflow: 'hidden',
 									maxHeight: '250px',
 									fontSize: '13px'

--- a/src/components/Jewelery.jsx
+++ b/src/components/Jewelery.jsx
@@ -7,7 +7,18 @@ import { Container } from 'react-bootstrap';
 export default function Jewelery(props) {
 	const [jewelery, setJewelery] = useState([]);
 	const [showDetail, setShowDetail] = useState(false); // Switch with detail page.
-	const [index, setIndex] = useState('');
+    const [index, setIndex] = useState('');
+    const [itemCount, setItemCount] = useState(localStorage.getItem('totalCount'))
+
+	const handleAddToCart = (event) => {
+		const total = parseInt(localStorage.getItem('totalCount'))
+		const preCount = parseInt(localStorage.getItem(event.target.offsetParent.id))
+		localStorage.setItem(event.target.offsetParent.id, (1 + preCount))
+        localStorage.setItem('totalCount', (total + 1))
+        setItemCount(total + 1)
+        // console.log(event.target.offsetParent.id)
+	};
+
 
 	function filterCategory(arr, categoryName) {
         return arr.filter((obj) => obj.category === categoryName);
@@ -65,6 +76,7 @@ export default function Jewelery(props) {
                                 }}
                                 price={data.price}
                                 onClick={handleShowDetail}
+                                addToCart={handleAddToCart}
                             />
                         })}
 

--- a/src/components/Jewelery.jsx
+++ b/src/components/Jewelery.jsx
@@ -17,7 +17,9 @@ export default function Jewelery(props) {
 	// Handle 'showDetail' status.
 	function handleShowDetail(event) {
 		setIndex(event.currentTarget.id);
-        setShowDetail(!showDetail);
+		if (event.target.localName !== 'button') {
+			setShowDetail(!showDetail)
+		}
 	}
 
 	useEffect(() => {
@@ -33,14 +35,14 @@ export default function Jewelery(props) {
         jewelery.length === 0 ? (
                 <>
                     <header>
-                        <Navigation />
+                        <Navigation count={localStorage.getItem('totalCount')} />
                     </header>
                     <section>Loading...</section>
                 </>
             ) : (
                 <>
                     <header>
-                        <Navigation />
+                        <Navigation count={localStorage.getItem('totalCount')} />
                     </header>
                     <Container
                         style={{

--- a/src/components/Men.jsx
+++ b/src/components/Men.jsx
@@ -17,7 +17,9 @@ export default function Men(props) {
 	// Handle 'showDetail' status.
 	function handleShowDetail(event) {
 		setIndex(event.currentTarget.id);
-        setShowDetail(!showDetail);
+		if (event.target.localName !== 'button') {
+			setShowDetail(!showDetail)
+		}
 	}
 
 	useEffect(() => {
@@ -33,14 +35,14 @@ export default function Men(props) {
         menClothing.length === 0 ? (
                 <>
                     <header>
-                        <Navigation />
+                        <Navigation count={localStorage.getItem('totalCount')} />
                     </header>
                     <section>Loading...</section>
                 </>
             ) : (
                 <>
                     <header>
-                        <Navigation />
+                        <Navigation count={localStorage.getItem('totalCount')} />
                     </header>
                     <Container
                         style={{

--- a/src/components/Men.jsx
+++ b/src/components/Men.jsx
@@ -7,7 +7,18 @@ import { Container } from 'react-bootstrap';
 export default function Men(props) {
 	const [menClothing, setMenClothing] = useState([]);
 	const [showDetail, setShowDetail] = useState(false); // Switch with detail page.
-	const [index, setIndex] = useState('');
+    const [index, setIndex] = useState('');
+    const [itemCount, setItemCount] = useState(localStorage.getItem('totalCount'))
+
+	const handleAddToCart = (event) => {
+		const total = parseInt(localStorage.getItem('totalCount'))
+		const preCount = parseInt(localStorage.getItem(event.target.offsetParent.id))
+		localStorage.setItem(event.target.offsetParent.id, (1 + preCount))
+        localStorage.setItem('totalCount', (total + 1))
+        setItemCount(total + 1)
+        // console.log(event.target.offsetParent.id)
+	};
+
 
 	function filterCategory(arr, categoryName) {
         return arr.filter((obj) => obj.category === categoryName);
@@ -65,6 +76,7 @@ export default function Men(props) {
                                 }}
                                 price={data.price}
                                 onClick={handleShowDetail}
+                                addToCart={handleAddToCart}
                             />
                         })}
 

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -10,7 +10,7 @@ import { LinkContainer } from 'react-router-bootstrap';
 
 export default function Navigation(props) {
 	const [isToggle, setToggle] = useState(false);
-	const [itemCout, setItemCount] = useState(props.count)
+	const [addCount, setAddCount] = useState(props.addCount)
 
 	return (
 		<>
@@ -37,7 +37,7 @@ export default function Navigation(props) {
 							<Nav.Link href="#Men's Clothing">Men's Clothing</Nav.Link>
 							<Nav.Link href="#Women's Clothing">Women's Clothing</Nav.Link>
 							<Nav.Link id="Cart">
-								<Cart isToggle={isToggle} setToggle={setToggle} />
+								<Cart isToggle={isToggle} setToggle={setToggle} addCount={addCount}/>
 							</Nav.Link>
 							<Nav.Link id="User">
 								<FontAwesomeIcon icon={faUserCircle} />

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -10,7 +10,6 @@ import { LinkContainer } from 'react-router-bootstrap';
 
 export default function Navigation(props) {
 	const [isToggle, setToggle] = useState(false);
-	const [addCount, setAddCount] = useState(props.addCount)
 
 	return (
 		<>
@@ -37,7 +36,7 @@ export default function Navigation(props) {
 							<Nav.Link href="#Men's Clothing">Men's Clothing</Nav.Link>
 							<Nav.Link href="#Women's Clothing">Women's Clothing</Nav.Link>
 							<Nav.Link id="Cart">
-								<Cart isToggle={isToggle} setToggle={setToggle} addCount={addCount}/>
+								<Cart isToggle={isToggle} setToggle={setToggle} count={props.count}/>
 							</Nav.Link>
 							<Nav.Link id="User">
 								<FontAwesomeIcon icon={faUserCircle} />

--- a/src/components/Women.jsx
+++ b/src/components/Women.jsx
@@ -7,7 +7,18 @@ import { Container } from 'react-bootstrap';
 export default function Women(props) {
 	const [womenClothing, setWomenClothing] = useState([]);
 	const [showDetail, setShowDetail] = useState(false); // Switch with detail page.
-	const [index, setIndex] = useState('');
+    const [index, setIndex] = useState('');
+    const [itemCount, setItemCount] = useState(localStorage.getItem('totalCount'))
+
+	const handleAddToCart = (event) => {
+		const total = parseInt(localStorage.getItem('totalCount'))
+		const preCount = parseInt(localStorage.getItem(event.target.offsetParent.id))
+		localStorage.setItem(event.target.offsetParent.id, (1 + preCount))
+        localStorage.setItem('totalCount', (total + 1))
+        setItemCount(total + 1)
+        // console.log(event.target.offsetParent.id)
+	};
+
 
 	function filterCategory(arr, categoryName) {
         return arr.filter((obj) => obj.category === categoryName);
@@ -65,6 +76,7 @@ export default function Women(props) {
                                 }}
                                 price={data.price}
                                 onClick={handleShowDetail}
+                                addToCart={handleAddToCart}
                             />
                         })}
 

--- a/src/components/Women.jsx
+++ b/src/components/Women.jsx
@@ -17,7 +17,9 @@ export default function Women(props) {
 	// Handle 'showDetail' status.
 	function handleShowDetail(event) {
 		setIndex(event.currentTarget.id);
-        setShowDetail(!showDetail);
+		if (event.target.localName !== 'button') {
+			setShowDetail(!showDetail)
+		}
 	}
 
 	useEffect(() => {
@@ -33,14 +35,14 @@ export default function Women(props) {
         womenClothing.length === 0 ? (
                 <>
                     <header>
-                        <Navigation />
+                        <Navigation count={localStorage.getItem('totalCount')} />
                     </header>
                     <section>Loading...</section>
                 </>
             ) : (
                 <>
                     <header>
-                        <Navigation />
+                        <Navigation count={localStorage.getItem('totalCount')} />
                     </header>
                     <Container
                         style={{


### PR DESCRIPTION
Add to cart button now can increase the number of item in shopping cart. I've create a local storage to store every item's count which is added to the cart. It will also be able to show items in cart panel by getting both id and count in local storage data.

This branch I've accidentally merge the ellipsis branch, cause I forgot to change my local branch. However, there was some conflict that I've remove it.

Every thing works well now, except of the home page to detail page problem.